### PR TITLE
Unnecessary parameter entailing errors in linux system

### DIFF
--- a/src/services/php-file-parser-service.ts
+++ b/src/services/php-file-parser-service.ts
@@ -70,7 +70,7 @@ export class PHPFileParserService {
             const args = ['-n'];
             if(forceJSON) {
                 const ext = this._ui.onWindows ? "dll" : "so";
-                args.push('-d', `extension=json.${ext}`);
+                //args.push('-d', `extension=json.${ext}`);
                 args.push('-d', `extension=tokenizer.${ext}`);
             }
             args.push(`"${path.join(path.dirname(__dirname), 'dump.php')}"`);


### PR DESCRIPTION
This is unnecessary parameter. On php.net documentation: "The JSON extension is bundled and compiled into PHP by default. As of PHP 8.0.0, the JSON extension is a core PHP extension, so it is always enabled."
So, file json.so is absent on last linux systems, and using "php -d  json.so" call error on Ubuntu 22.04 php 8.1, for example.
May be it would be better realise an option to select compatible whith old version php on linux systems.